### PR TITLE
Remove information about centralize generation

### DIFF
--- a/src/components/BeforeGeneration.tsx
+++ b/src/components/BeforeGeneration.tsx
@@ -31,6 +31,7 @@ const container = classnames(
 const bottomPart = classnames(
   display('flex'),
   flexDirection('flex-col'),
+  alignItems('items-center'),
   gap('gap-y-2')
 )
 const buttonsWrapper = classnames(
@@ -51,7 +52,7 @@ const buttonCaption = classnames(displayFrom('sm'), padding('px-9'))
 
 export default function () {
   const { input } = useSnapshot(AppStore)
-  const isHidden = true
+  const isVisible = false
   const tooltipText =
     'Using a centralized server won’t be as secure as if you generated yourself locally in browser. Although we’ll do everything we can to protect data, it’ll never be as anonymous. '
 
@@ -89,20 +90,20 @@ export default function () {
           <div className={displayTo('sm')}>
             <CaptionText>Happens locally in browser</CaptionText>
           </div>
-
-          <AccentText color="text-primary-semi-dimmed">or</AccentText>
-
-          {isHidden && (
-            <div className={tooltipWrapper}>
-              <GradientText center>
-                Generate on a centralized prover
-              </GradientText>
-              <Tooltip fitContainer position="bottom-end" text={tooltipText}>
-                <span>
-                  <CharInCircle char="?" />
-                </span>
-              </Tooltip>
-            </div>
+          {isVisible && (
+            <>
+              <AccentText color="text-primary-semi-dimmed">or</AccentText>
+              <div className={tooltipWrapper}>
+                <GradientText center>
+                  Generate on a centralized prover
+                </GradientText>
+                <Tooltip fitContainer position="bottom-end" text={tooltipText}>
+                  <span>
+                    <CharInCircle char="?" />
+                  </span>
+                </Tooltip>
+              </div>
+            </>
           )}
         </div>
         <div className={buttonCaption}>


### PR DESCRIPTION
- hide block about `centralized prover`

<img width="642" alt="Снимок экрана 2022-11-14 в 13 09 40" src="https://user-images.githubusercontent.com/5114069/201633335-b8477002-aa59-4cfc-a177-4bfd1132d0eb.png">
