### PR TITLE
Set tooltip position in the center for mobiles

### DIFF
--- a/src/components/BeforeGeneration.tsx
+++ b/src/components/BeforeGeneration.tsx
@@ -10,8 +10,7 @@ import { displayFrom, displayTo } from 'helpers/visibilityClassnames'
 import { useSnapshot } from 'valtio'
 import AppStore from 'stores/AppStore'
 import Button from 'components/Button'
-import CharInCircle from 'components/CharInCircle'
-import Tooltip from 'components/Tooltip'
+import CentralizedProverHint from 'components/CentralizedProverHint'
 import classnames, {
   alignItems,
   display,
@@ -97,11 +96,7 @@ export default function () {
               <GradientText center>
                 Generate on a centralized prover
               </GradientText>
-              <Tooltip fitContainer position="bottom-end" text={tooltipText}>
-                <span>
-                  <CharInCircle char="?" />
-                </span>
-              </Tooltip>
+              <CentralizedProverHint text={tooltipText} />
             </div>
           )}
         </div>

--- a/src/components/CentralizedProverHint.tsx
+++ b/src/components/CentralizedProverHint.tsx
@@ -1,0 +1,34 @@
+import { displayFrom, displayTo } from 'helpers/visibilityClassnames'
+import CharInCircle from 'components/CharInCircle'
+import Tooltip from 'components/Tooltip'
+
+const TooltipHint = ({
+  bottomEnd = false,
+  text,
+}: {
+  bottomEnd?: boolean
+  text: string
+}) => {
+  const position = bottomEnd ? 'bottom-end' : 'bottom'
+
+  return (
+    <Tooltip fitContainer position={position} text={text}>
+      <span>
+        <CharInCircle char="?" />
+      </span>
+    </Tooltip>
+  )
+}
+
+export default function ({ text }: { text: string }) {
+  return (
+    <>
+      <div className={displayFrom('sm')}>
+        <TooltipHint bottomEnd text={text} />
+      </div>
+      <div className={displayTo('sm')}>
+        <TooltipHint text={text} />
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
- created a tooltip wrapper
- set the tooltip position on mobiles in the center

<img width="377" alt="Снимок экрана 2022-11-14 в 14 34 19" src="https://user-images.githubusercontent.com/5114069/201649990-58532e4e-ed4d-4257-97a4-465aa98ff1de.png">
