### PR TITLE
Fix server generation subtitle + return signingFlow back

### DIFF
--- a/src/components/Common/ConnectWalletButton.tsx
+++ b/src/components/Common/ConnectWalletButton.tsx
@@ -2,7 +2,7 @@ import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { Phase } from 'models/FlowPhase'
 import AppStore from 'stores/AppStore'
 import Button from 'components/Common/Button'
-import SigningFlow from 'components/Flow/SigningFlow'
+import SigningFlow from 'components/SigningFlow'
 import Spinner from 'icons/Spinner'
 import classnames, {
   alignItems,

--- a/src/components/Flow/DecentralizedFlow.tsx
+++ b/src/components/Flow/DecentralizedFlow.tsx
@@ -3,7 +3,7 @@ import { useSnapshot } from 'valtio'
 import AppStore from 'stores/AppStore'
 import JobStore from 'stores/JobStore'
 import OptionStatus from 'components/StatusesList/OptionStatus'
-import SigningStates, { generatingFlow } from 'models/SigningStates'
+import SigningStates, { States, generatingFlow } from 'models/SigningStates'
 import StatusesList from 'components/StatusesList'
 import checkIfStateCompleted from 'helpers/checkIfStateCompleted'
 
@@ -12,9 +12,10 @@ export default function () {
   const { jobId } = useSnapshot(JobStore)
   const { subTitle } = SigningStates[flowState]
 
-  const serverCaption = jobId
-    ? ' Feel free to leave and come back—we’ll still be here.'
-    : ''
+  const serverCaption =
+    jobId && flowState === States.generateProof
+      ? ' Feel free to leave and come back—we’ll still be here.'
+      : ''
   const description = subTitle + serverCaption
   const jobStatus = error ? errorList[error] : description
   const isError = !!error

--- a/src/components/SigningFlow.tsx
+++ b/src/components/SigningFlow.tsx
@@ -54,8 +54,8 @@ export default function () {
 
         if (supportsModuleWorkers()) {
           const { generateInput } = new ComlinkWorker<
-            typeof import('../../helpers/proofs/createProof')
-          >(new URL('./../../../helpers/proofs/createProof', import.meta.url))
+            typeof import('../helpers/proofs/createProof')
+          >(new URL('../helpers/proofs/createProof', import.meta.url))
           AppStore.input = await generateInput(signature, baseMessage)
         } else {
           AppStore.input = generateInput(signature, baseMessage)

--- a/src/data/phaseData.tsx
+++ b/src/data/phaseData.tsx
@@ -4,7 +4,7 @@ import CentralizedProver from 'components/BeforeGeneration/CentralizedProver'
 import DecentralizedFlow from 'components/Flow/DecentralizedFlow'
 import DecentralizedProver from 'components/BeforeGeneration/DecentralizedProver'
 import GettingStartedBlock from 'components/Common/GettingStartedBlock'
-import SigningFlow from 'components/Flow/SigningFlow'
+import SigningFlow from 'components/SigningFlow'
 import SuccessCardBlock from 'components/SuccessCard/SuccessCardBlock'
 import SuccessSubtitle from 'components/SuccessCard/SuccessSubtitle'
 


### PR DESCRIPTION
- fixed subtitle when server generation is running
- returned back `SigningFlow` back to components
- returned paths to worker
