### PR TITLE
Update network resolver

### DIFF
--- a/src/components/Navbar/AccountBlock.tsx
+++ b/src/components/Navbar/AccountBlock.tsx
@@ -3,7 +3,7 @@ import { useDisconnect, useNetwork } from 'wagmi'
 import AppStore from 'stores/AppStore'
 import Dropdown from 'components/Dropdown'
 import ENSAddress from 'components/Navbar/ENSAddress'
-import getEtherscanAddressUrl from 'helpers/getEtherscanAddressUrl'
+import getEtherscanUrl from 'helpers/getEtherscanUrl'
 
 const options = [
   { label: 'Etherscan', value: 'etherscan' },
@@ -29,7 +29,14 @@ export default function ({ address }: { address: string }) {
     } else {
       address &&
         chain &&
-        window.open(getEtherscanAddressUrl(address, chain.network), '_blank')
+        window.open(
+          getEtherscanUrl({
+            chainId: chain.id,
+            type: 'address',
+            value: address,
+          }),
+          '_blank'
+        )
     }
   }
 

--- a/src/components/SuccessCard/SuccessCardBlock.tsx
+++ b/src/components/SuccessCard/SuccessCardBlock.tsx
@@ -6,7 +6,7 @@ import Checkmark from 'icons/Checkmark'
 import SealStar from 'icons/SealStar'
 import StatusBlock from 'components/StatusBlock'
 import classnames, { alignItems, display, gap } from 'classnames/tailwind'
-import getEtherscanTxUrl from 'helpers/getEtherscanTxUrl'
+import getEtherscanUrl from 'helpers/getEtherscanUrl'
 
 const successText = classnames(
   display('flex'),
@@ -35,7 +35,11 @@ export default function () {
             <>
               Here’s a link to your{' '}
               <LinkText
-                url={getEtherscanTxUrl(commitmentTxHash, chain.network)}
+                url={getEtherscanUrl({
+                  chainId: chain.id,
+                  type: 'tx',
+                  value: commitmentTxHash,
+                })}
               >
                 commitment on etherscan
               </LinkText>

--- a/src/helpers/getEtherscanAddressUrl.ts
+++ b/src/helpers/getEtherscanAddressUrl.ts
@@ -1,7 +1,0 @@
-import resolveNetworkForEtherscan from 'helpers/resolveNetworkForEtherscan'
-
-export default function (address: string, network: string) {
-  return `https://${resolveNetworkForEtherscan(
-    network
-  )}etherscan.io/address/${address}`
-}

--- a/src/helpers/getEtherscanTxUrl.ts
+++ b/src/helpers/getEtherscanTxUrl.ts
@@ -1,7 +1,0 @@
-import resolveNetworkForEtherscan from 'helpers/resolveNetworkForEtherscan'
-
-export default function (txHash: string, network: string) {
-  return `https://${resolveNetworkForEtherscan(
-    network
-  )}goerli.etherscan.io/tx/${txHash}`
-}

--- a/src/helpers/getEtherscanUrl.ts
+++ b/src/helpers/getEtherscanUrl.ts
@@ -1,0 +1,13 @@
+import resolveNetworkForEtherscan from 'helpers/resolveNetworkForEtherscan'
+
+export default function ({
+  chainId,
+  type,
+  value,
+}: {
+  chainId: number
+  type: 'address' | 'tx'
+  value: string
+}) {
+  return `${resolveNetworkForEtherscan(chainId)}/${type}/${value}`
+}

--- a/src/helpers/resolveNetworkForEtherscan.ts
+++ b/src/helpers/resolveNetworkForEtherscan.ts
@@ -1,3 +1,8 @@
-export default function (network: string) {
-  return network === 'homestead' ? '' : `${network.toLowerCase()}.`
+import * as Networks from 'wagmi/chains'
+
+export default function (chainId: number) {
+  const chain = Object.values(Networks).find((chain) => chain.id === chainId)
+  return !chain || !chain.blockExplorers?.etherscan?.url
+    ? 'https://etherscan.io'
+    : chain.blockExplorers.etherscan.url
 }

--- a/src/helpers/resolveNetworkForEtherscan.ts
+++ b/src/helpers/resolveNetworkForEtherscan.ts
@@ -2,7 +2,7 @@ import * as Networks from 'wagmi/chains'
 
 export default function (chainId: number) {
   const chain = Object.values(Networks).find((chain) => chain.id === chainId)
-  return !chain || !chain.blockExplorers?.etherscan?.url
-    ? 'https://etherscan.io'
-    : chain.blockExplorers.etherscan.url
+  return chain && chain.blockExplorers?.etherscan?.url
+    ? chain.blockExplorers.etherscan.url
+    : 'https://etherscan.io'
 }


### PR DESCRIPTION
- removed `getEtherscanTxUrl` & `getEtherscanAddressUrl` helpers
- updated `resolveNetworkForEtherscan` helper
- created `getEtherscanUrl` helper
- now, whatever network is used it will set the right scanUrl to user
